### PR TITLE
Delivery id test failure

### DIFF
--- a/src/test/java/ie/atu/food_delivery_app/DeliveryDriverTestFails.java
+++ b/src/test/java/ie/atu/food_delivery_app/DeliveryDriverTestFails.java
@@ -1,0 +1,4 @@
+package ie.atu.food_delivery_app;
+
+public class DeliveryDriverTestFails {
+}

--- a/src/test/java/ie/atu/food_delivery_app/DeliveryDriverTestFails.java
+++ b/src/test/java/ie/atu/food_delivery_app/DeliveryDriverTestFails.java
@@ -1,4 +1,23 @@
 package ie.atu.food_delivery_app;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 public class DeliveryDriverTestFails {
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void testTitleFail(){
+        Exception exMessage = assertThrows(IllegalArgumentException.class, () -> new DeliveryDriver("Mister", "Conor", "1111111111", "879543461", "2233445566", 21));
+        assertEquals("Please enter Mr, Mrs or Ms", exMessage.getMessage());
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
 }


### PR DESCRIPTION
Added code to test for any failure when user inputs a title
Changed "lambda" statement or format used with fails to expression "lambda". A wanting came up saying "Warning:(15,82) Statement lambda can be replaced with expression lambda"